### PR TITLE
Better crash detection

### DIFF
--- a/lib/sentry_log_capture.ex
+++ b/lib/sentry_log_capture.ex
@@ -44,8 +44,6 @@ defmodule SentryLogCapture do
         state = %{level: min_level, fingerprint_callback: fingerprint_callback}
       ) do
     msg = to_string(msg)
-    IO.inspect(metadata)
-    IO.inspect(is_otp_crash(metadata))
 
     if meet_level?(level, min_level) && !metadata[:skip_sentry] && !is_otp_crash(metadata) do
       {fingerprint_meta, remaining} = Keyword.pop(metadata, :fingerprint)


### PR DESCRIPTION
This PR updates the OTP crash detection. Previously, the library was checking if a log started with "Error in process" but this is brittle. Instead, we're looking at metadata that contains a `crash_reason` and has the `otp` domain.